### PR TITLE
TREE-2341 | add zhutils functions

### DIFF
--- a/packages/app/config/webpack.prod.js
+++ b/packages/app/config/webpack.prod.js
@@ -85,6 +85,11 @@ module.exports = merge(commonConfig, {
       new BundleAnalyzerPlugin({
         analyzerMode: 'static',
       }),
+    new webpack.DefinePlugin({
+      'process.env.ZH_EXAMPLE_VAR': JSON.stringify(
+        process.env.ZH_EXAMPLE_VAR || ''
+      ),
+    }),
     new webpack.DefinePlugin({ VERSION: JSON.stringify(VERSION) }),
     // Generate a service worker script that will precache, and keep up to date,
     // the HTML & assets that are part of the Webpack build.

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -48,7 +48,6 @@ import { startServiceWorker } from './worker';
 import {
   dispatchCompiledCode,
   getZhExampleBuildVar,
-  getZhSandpackMode,
   makeZhRequest,
 } from './zh-utils';
 
@@ -339,7 +338,9 @@ async function initializeManager(
     teamId?: string;
   } = {}
 ) {
-  makeZhRequest(customNpmRegistries, 'bundle');
+  // zeroheight request to confirm CORS is set up correctly
+  // and token is providing auth
+  makeZhRequest('bundle');
 
   const newManager = new Manager(
     sandboxId,
@@ -550,7 +551,6 @@ interface CompileOptions {
 async function compile(opts: CompileOptions) {
   // get zeroheight root domain from build var
   console.log({
-    modeFromSubdomain: getZhSandpackMode(),
     exampleVar: getZhExampleBuildVar(),
   });
   const {

--- a/packages/app/src/sandbox/compile.ts
+++ b/packages/app/src/sandbox/compile.ts
@@ -45,6 +45,12 @@ import setScreen, { resetScreen } from './status-screen';
 import { showRunOnClick } from './status-screen/run-on-click';
 import { SCRIPT_VERSION } from '.';
 import { startServiceWorker } from './worker';
+import {
+  dispatchCompiledCode,
+  getZhExampleBuildVar,
+  getZhSandpackMode,
+  makeZhRequest,
+} from './zh-utils';
 
 let manager: Manager | null = null;
 let actionsEnabled = false;
@@ -333,6 +339,8 @@ async function initializeManager(
     teamId?: string;
   } = {}
 ) {
+  makeZhRequest(customNpmRegistries, 'bundle');
+
   const newManager = new Manager(
     sandboxId,
     await getPreset(template, configurations.package.parsed),
@@ -540,6 +548,11 @@ interface CompileOptions {
 }
 
 async function compile(opts: CompileOptions) {
+  // get zeroheight root domain from build var
+  console.log({
+    modeFromSubdomain: getZhSandpackMode(),
+    exampleVar: getZhExampleBuildVar(),
+  });
   const {
     sandboxId,
     modules,
@@ -772,6 +785,8 @@ async function compile(opts: CompileOptions) {
     metrics.endMeasure('transpilation', { displayName: 'Transpilation' });
 
     dispatch({ type: 'status', status: 'evaluating' });
+
+    dispatchCompiledCode('uniqueHash', 'somethingsomethingtranspiled');
     manager.setStage('evaluation');
 
     if (!skipEval) {

--- a/packages/app/src/sandbox/index.ts
+++ b/packages/app/src/sandbox/index.ts
@@ -16,6 +16,7 @@ import {
   removeSandpackSecret,
 } from 'sandpack-core/lib/sandpack-secret';
 import compile, { getCurrentManager } from './compile';
+import { setZhToken } from './zh-utils';
 
 const withServiceWorker = !process.env.SANDPACK;
 const debug = _debug('cs:sandbox');
@@ -40,6 +41,9 @@ requirePolyfills().then(() => {
   let isInitializationCompile = true;
   async function handleMessage(data, source) {
     if (source) {
+      if (data.type === 'zh_cache_config') {
+        setZhToken(data.token, data.url);
+      }
       if (data.type === 'compile') {
         // In sandpack we always broadcast a compile message from every manager whenever 1 frame reconnects.
         // We do this because the initialized message does comes before the handshake is done, so there's no channel id.

--- a/packages/app/src/sandbox/zh-utils.ts
+++ b/packages/app/src/sandbox/zh-utils.ts
@@ -1,0 +1,39 @@
+import { NpmRegistry } from '@codesandbox/common/lib/types';
+import { dispatch } from 'codesandbox-api';
+
+export const getZhSandpackMode = (): 'editor' | 'viewer' => {
+  return window.location.host.split('.')[0] === 'editor' ? 'editor' : 'viewer';
+};
+
+export const getZhExampleBuildVar = () => {
+  // example variable we can get from build variables
+  return process.env.ZH_EXAMPLE_VAR;
+};
+
+export const makeZhRequest = async (
+  registries: NpmRegistry[],
+  path: string,
+  init: RequestInit = {}
+) => {
+  // example using the custom registries data to pass specific
+  const sandpackDetails = registries.find(
+    registry =>
+      registry.enabledScopes.length === 1 &&
+      registry.enabledScopes[0] === '@zh-engineer/livecode'
+  );
+
+  if (sandpackDetails) {
+    await fetch(`${sandpackDetails.registryUrl}${path}`, {
+      headers: { authorization: `Bearer ${sandpackDetails.registryAuthToken}` },
+      ...init,
+    });
+  }
+};
+
+export const dispatchCompiledCode = (hash: string, code: any) => {
+  dispatch({
+    type: 'zh_compiled_code',
+    hash,
+    code,
+  });
+};


### PR DESCRIPTION
### Description

Using the new helper methods, we will be able to

1. Send requests to the app backend that contain an token validating the styleguide id and access to the bundle feature
2. dispatch events containing the compiled code to the zeroheight app in the parent window

I have also added in an example of passing data to the compiled bundler during build, however it looks like we will not need this due to getting the information we need out of the custom registries data

**Why pass the token / url via the custom registries data?** 
While this is not the original intent for the customNpmRegistries property, which holds data about where to fetch packages from, the format (private token + url) is very close to what we need. 